### PR TITLE
Add GetOrAttach method to registry

### DIFF
--- a/includes/fecs/registry/registry.h
+++ b/includes/fecs/registry/registry.h
@@ -235,6 +235,27 @@ namespace FECS
             return result;
         }
 
+        /**
+         * @brief  Retrieve a component of type C for an entity, attaching it if not already present.
+         *
+         * This is a convenience wrapper around Has<T>, Attach<T> and Get<T>.
+         * If the entity does not yet have a T, a default-constructed T is attached;
+         * otherwise the existing component is returned.
+         *
+         * @tparam C            The component type to retrieve or attach.
+         * @param  id           The entity identifier.
+         * @return C&           Reference to the component instance on the entity.
+         */
+        template <typename C>
+        C& GetOrAttach(FECS::Entity id)
+        {
+            if (!Has<C>(id))
+            {
+                Attach<C>(id);
+            }
+            return Get<C>(id);
+        }
+
     private:
         Manager::EntityManager m_EntityManager; ///< The internal entity manager.
     };


### PR DESCRIPTION
Introduces the GetOrAttach template method to retrieve a component for an entity, attaching a default-constructed component if it does not already exist. This provides a convenient way to ensure an entity has a specific component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new method that automatically attaches and retrieves a component for an entity if it does not already exist, streamlining component management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->