### PR TITLE
Update GetOrAttach to accept component parameter

### DIFF
--- a/includes/fecs/registry/registry.h
+++ b/includes/fecs/registry/registry.h
@@ -247,11 +247,11 @@ namespace FECS
          * @return C&           Reference to the component instance on the entity.
          */
         template <typename C>
-        C& GetOrAttach(FECS::Entity id)
+        C& GetOrAttach(FECS::Entity id, const C& component)
         {
             if (!Has<C>(id))
             {
-                Attach<C>(id);
+                Attach<C>(id, component);
             }
             return Get<C>(id);
         }


### PR DESCRIPTION
The GetOrAttach method now takes a component instance as a parameter and passes it to Attach, allowing initialization of the component when attaching to an entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component attachment behavior: When adding a component to an entity, users can now specify the exact component instance to attach if it does not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->